### PR TITLE
Strengthen `trim` test to test it with writes that start or end mid-cell

### DIFF
--- a/test/trim.coffee
+++ b/test/trim.coffee
@@ -141,7 +141,12 @@ describe 'trim', ->
      Test 8 ,," 800000,800000 ",""""
      Test 9 ,," 900000,900000 ",""""
     '''
-    parser.write i for i in buffer
+    # Intentionally create writes that get break in the middle of cells.
+    for i in [0...10]
+      if buffer.length > 18
+        parser.write buffer.substr 0, 18
+        buffer = buffer.substr 18
+    parser.write buffer
     parser.end()
 
 describe 'no trim', ->


### PR DESCRIPTION
I check the test coverage recently added for trim by testing the addition of the test coverage without the fix. 

A bug with trim coverage was shown, but the test was covering the mid-cell truncation I had found earlier which is triggered in part when trim is enabled. 

This updated test coverage also covers the mid-cell truncation issue with trim. This test coverage still passes, confirming the mid-cell truncation issue is fixed. 