### PR TITLE
Fix issue when reading a csv file and no options argument is passed in

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12,7 +12,7 @@ module.exports = function() {
     options = arguments[1];
     callback = arguments[2];
   } else if (arguments.length === 2) {
-    if (typeof arguments[0] === 'string') {
+    if (typeof arguments[0] === 'string' || Buffer.isBuffer(arguments[0])) {
       data = arguments[0];
     } else {
       options = arguments[0];

--- a/src/index.coffee.md
+++ b/src/index.coffee.md
@@ -27,7 +27,7 @@ Callback approach, for ease of use:
         options = arguments[1]
         callback = arguments[2]
       else if arguments.length is 2
-        if typeof arguments[0] is 'string'
+        if typeof arguments[0] is 'string' || Buffer.isBuffer arguments[0]
         then data = arguments[0]
         else options = arguments[0]
         if typeof arguments[1] is 'function'

--- a/test/buffer.coffee
+++ b/test/buffer.coffee
@@ -1,0 +1,12 @@
+
+should = require 'should'
+parse = if process.env.CSV_COV then require '../lib-cov' else require '../src'
+
+describe 'buffer', ->
+
+  it 'should consider data the first argument when reading from a csv file and no options are passed in', (next) ->
+    parse new Buffer('hello,world'), (err, data) ->
+      return next err if err
+
+      data.should.match [ [ 'hello', 'world' ] ]
+      next()


### PR DESCRIPTION
I was parsing a CSV file, using the callbacks, following the example @wdavidw gave per issue #28.

```
fs.readFile(path.join(__dirname,'../data/ex.csv'), function(err, data) {
    if(err) { res.send(err); }

    parse(data, function(err, rows) {
      res.send(rows);
    });
});
```

When trying that without passing the options argument, it would time out.

After poking around for a bit, I found that when passing in two args (no ```options```), there was a check on whether the data object is a string. However, because I'm using ```fs.readFile```, the data is a Buffer object. Therefore, the Buffer is assigned to  ```options```, which breaks the parser.

I added a check on whether ```data``` was a Buffer, which seems to fix that specific use case, and added a test for that case.