### PR TITLE
Added one test case to test a line ends with field delimiter and without...

### DIFF
--- a/test/rowDelimiter.coffee
+++ b/test/rowDelimiter.coffee
@@ -83,3 +83,11 @@ describe 'rowDelimiter', ->
     parser.write '\n'
     parser.write 'def,456'
     parser.end()
+
+  it 'Test line ends with field delimiter and without row delimiter', (next) ->
+    parse '"a","b","c",', delimiter: ',', (err, data) ->
+      return next err if err
+      data.should.eql [
+        [ 'a','b','c','' ]
+      ]
+      next()


### PR DESCRIPTION
Added one test case to test a line ends with field delimiter and without row delimiter

I found this error:
```
     TypeError: Cannot read property 'length' of null
    at [object Object].Parser.__write (/Users/max/work/github/node-csv-parse/src/index.coffee.md:311:41)
    at [object Object].Parser._flush (/Users/max/work/github/node-csv-parse/src/index.coffee.md:149:12)
    at [object Object].<anonymous> (_stream_transform.js:130:12)
    at [object Object].g (events.js:180:16)
    at [object Object].emit (events.js:92:17)
    at finishMaybe (_stream_writable.js:359:12)
    at endWritable (_stream_writable.js:366:3)
    at [object Object].Writable.end (_stream_writable.js:344:5)
    at /Users/max/work/github/node-csv-parse/src/index.coffee.md:39:23
    at process._tickCallback (node.js:419:13)
```
 when parsing the following string:
```javascript
var str = '"a","b","c",';
```
Unfortunate, I can't fixed this issue yet, this pull request contains only a test case that will fail.
