### PR TITLE
make auto_parse assume 0 prefixed ints are strings

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -120,7 +120,7 @@ Parser = function(options) {
   this.closingQuote = 0;
   this.line = [];
   this.chunks = [];
-  this.intRegexp = /^(\-|\+)?([0-9]+)$/;
+  this.intRegexp = /^(\-|\+)?([1-9]+[0-9]*)$/;
   this.floatRegexp = /^(\-|\+)?([0-9]+(\.[0-9]+)?([eE][0-9]+)?|Infinity)$/;
   return this;
 };

--- a/src/index.coffee.md
+++ b/src/index.coffee.md
@@ -90,7 +90,7 @@ Options are documented [here](http://csv.adaltas.com/parse/).
       @closingQuote = 0
       @line = [] # Current line being processed
       @chunks = []
-      @intRegexp = /^(\-|\+)?([0-9]+)$/
+      @intRegexp = /^(\-|\+)?([1-9]+[0-9]*)$/
       @floatRegexp = /^(\-|\+)?([0-9]+(\.[0-9]+)?([eE][0-9]+)?|Infinity)$/
       # @floatRegexp = /^(\-|\+)?([0-9]+(\.[0-9]+)?|Infinity)$/
       @

--- a/test/write.coffee
+++ b/test/write.coffee
@@ -35,6 +35,25 @@ describe 'write', ->
       next()
     parser.end()
 
+  it 'should read ints as strings if they are zeroed first', (next) ->
+    data = []
+    parser = parse({ auto_parse: true })
+    parser.write """
+    1234 Blueberry Hill,01102
+    """
+    parser.on 'readable', ->
+      while(d = parser.read())
+        data.push d
+    parser.on 'error', (err) ->
+      next err
+    parser.on 'finish', ->
+      data.should.eql [
+        ["1234 Blueberry Hill", "01102"]
+      ]
+      (typeof data[0][1]).should.eql 'string'
+      next()
+    parser.end()
+
   it 'string randomly splited', (next) ->
     data = []
     parser = parse()


### PR DESCRIPTION
This is specifically useful with zipcodes, which can start with 0. Eg. `01010`.