### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,10 +21,7 @@
     "Joe Eaves (https://github.com/Joeasaurus)",
     "Mark Stosberg (https://github.com/markstos)"
   ],
-  "licenses": [{
-    "type": "BSD",
-    "url": "https://github.com/wdavidw/node-csv-parse/blob/master/LICENSE"
-  }],
+  "license": "BSD-3-Clause",
   "repository": {
     "type": "git",
     "url": "http://www.github.com/wdavidw/node-csv-parse"


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/