### PR TITLE
Add sync test for objname option.

### DIFF
--- a/test/sync.coffee
+++ b/test/sync.coffee
@@ -20,7 +20,7 @@ describe 'sync', ->
     data = parse 'field_1,field_2\nname 1,value 1\nname 2, value 2', objname: 'field_1', columns: true
     data.should.eql {
       'name 1': {'field_1': 'name 1', 'field_2': 'value 1'},
-      'name 2': {'field_1': 'name 1', 'field_2': 'value 1'}
+      'name 2': {'field_1': 'name 2', 'field_2': 'value 2'}
     }
     
     

--- a/test/sync.coffee
+++ b/test/sync.coffee
@@ -15,6 +15,13 @@ describe 'sync', ->
   it 'honors columns option', ->
     data = parse 'field_1,field_2\nvalue 1,value 2', columns: true
     data.should.eql [ 'field_1': 'value 1', 'field_2': 'value 2' ]
+
+  it 'honors objname option', ->
+    data = parse 'field_1,field_2\nname 1,value 1\nname 2, value 2', objname: 'field_1', columns: true
+    data.should.eql {
+      'name 1': {'field_1': 'name 1', 'field_2': 'value 1'},
+      'name 2': {'field_1': 'name 1', 'field_2': 'value 1'}
+    }
     
     
     


### PR DESCRIPTION
With the Synchronous API,  parse with the objname option doesn't produce the same object as with the Callback API.

This pull-request adds a failing test for sync parse to help debug the problem. Here's the test output:

```
1) sync honors objname option:
     AssertionError: expected Array [
  Array [ 'name 1', Object { field_1: 'name 1', field_2: 'value 1' } ],
  Array [ 'name 2', Object { field_1: 'name 2', field_2: ' value 2' } ]
] to equal Object {
  'name 1': Object { field_1: 'name 1', field_2: 'value 1' },
  'name 2': Object { field_1: 'name 2', field_2: 'value 2' }
}
```