### PR TITLE
Implement `raw` option

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -185,13 +185,15 @@ Parser.prototype._flush = function(callback) {
 };
 
 Parser.prototype.__push = function(line) {
-  var field, i, j, len, lineAsColumns, row;
+  var field, i, j, len, lineAsColumns, rawBuf, row;
   row = null;
   if (this.options.columns === true) {
     this.options.columns = line;
+    rawBuf = '';
     return;
   } else if (typeof this.options.columns === 'function') {
     this.options.columns = this.options.columns(line);
+    rawBuf = '';
     return;
   }
   this.count++;

--- a/lib/index.js
+++ b/lib/index.js
@@ -144,6 +144,7 @@ Parser = function(options) {
   this.closingQuote = 0;
   this.line = [];
   this.chunks = [];
+  this.rawBuf = '';
   return this;
 };
 
@@ -152,7 +153,7 @@ util.inherits(Parser, stream.Transform);
 module.exports.Parser = Parser;
 
 Parser.prototype._transform = function(chunk, encoding, callback) {
-  var err;
+  var err, error;
   if (chunk instanceof Buffer) {
     chunk = this.decoder.write(chunk);
   }
@@ -166,7 +167,7 @@ Parser.prototype._transform = function(chunk, encoding, callback) {
 };
 
 Parser.prototype._flush = function(callback) {
-  var err;
+  var err, error;
   try {
     this.__write(this.decoder.end(), true);
     if (this.quoting) {
@@ -184,7 +185,8 @@ Parser.prototype._flush = function(callback) {
 };
 
 Parser.prototype.__push = function(line) {
-  var field, i, j, len, lineAsColumns;
+  var field, i, j, len, lineAsColumns, row;
+  row = null;
   if (this.options.columns === true) {
     this.options.columns = line;
     return;
@@ -200,12 +202,21 @@ Parser.prototype.__push = function(line) {
       lineAsColumns[this.options.columns[i]] = field;
     }
     if (this.options.objname) {
-      return this.push([lineAsColumns[this.options.objname], lineAsColumns]);
+      row = [lineAsColumns[this.options.objname], lineAsColumns];
     } else {
-      return this.push(lineAsColumns);
+      row = lineAsColumns;
     }
   } else {
-    return this.push(line);
+    row = line;
+  }
+  if (this.options.raw) {
+    this.push({
+      raw: this.rawBuf,
+      row: row
+    });
+    return this.rawBuf = '';
+  } else {
+    return this.push(row);
   }
 };
 
@@ -264,6 +275,9 @@ Parser.prototype.__write = function(chars, end, callback) {
     }
     char = this.nextChar ? this.nextChar : chars.charAt(i);
     this.nextChar = chars.charAt(i + 1);
+    if (this.options.raw) {
+      this.rawBuf += char;
+    }
     if (this.options.rowDelimiter == null) {
       if ((this.field === '') && (char === '\n' || char === '\r')) {
         rowDelimiter = char;
@@ -271,6 +285,9 @@ Parser.prototype.__write = function(chars, end, callback) {
       } else if (this.nextChar === '\n' || this.nextChar === '\r') {
         rowDelimiter = this.nextChar;
         nextCharPos = i + 2;
+        if (this.raw) {
+          rawBuf += this.nextChar;
+        }
       }
       if (rowDelimiter) {
         if (rowDelimiter === '\r' && chars.charAt(nextCharPos) === '\n') {
@@ -289,6 +306,9 @@ Parser.prototype.__write = function(chars, end, callback) {
         char = this.nextChar;
         this.nextChar = chars.charAt(i + 1);
         this.field += char;
+        if (this.options.raw) {
+          this.rawBuf += char;
+        }
         i++;
         continue;
       }

--- a/src/index.coffee.md
+++ b/src/index.coffee.md
@@ -160,9 +160,11 @@ Implementation of the [`stream.Transform` API][transform]
       row = null
       if @options.columns is true
         @options.columns = line
+        rawBuf = ''
         return
       else if typeof @options.columns is 'function'
         @options.columns = @options.columns line
+        rawBuf = ''
         return
       @count++
       if @options.columns?

--- a/test/raw.coffee
+++ b/test/raw.coffee
@@ -1,0 +1,38 @@
+
+require 'should'
+parse = if process.env.CSV_COV then require '../lib-cov' else require '../src'
+
+describe 'raw', ->
+  it 'includes escape chars', ->
+    str = """
+    "hello""world",LOL
+    """
+    parse str, escape: '"', (err, data) ->
+      data[0].raw.should.eql str
+
+  it 'includes line breaks', ->
+    parse """
+    hello
+    my
+    friend
+    """, escape: '"', (err, data) ->
+      data[1].raw.should.match /\n$/
+
+  it 'skips columns', ->
+    parse """
+    name,last name
+    Boudreau,Jonathan
+    """, {}, (err, data) ->
+      data[0].raw.should.not.contain 'name'
+
+  it 'has the inner line breaks', ->
+    str = """
+    foo,"b
+    a
+    r"
+    """
+    parse str, escape: '"', (err, data) ->
+      data[0].raw.should.eql str
+    
+
+ 


### PR DESCRIPTION
This adds a `raw` option which will make each csv row parsed into an object containing two properties:
- `raw`: a string which is the original data that was parsed.
- `row`: an array _or_ object (depending on other options used) which is the parsed row.

Fixes issue #85 