### PR TITLE
Catch errors thrown in the columns function and emit them

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -63,11 +63,14 @@ module.exports = function() {
       return results;
     });
     parser.on('error', function(err) {
-      called = true;
-      return callback(err);
+      if (!called) {
+        called = true;
+        return callback(err);
+      }
     });
     parser.on('end', function() {
       if (!called) {
+        called = true;
         return callback(null, chunks);
       }
     });

--- a/lib/index.js
+++ b/lib/index.js
@@ -198,7 +198,11 @@ Parser.prototype.__push = function(line) {
     this.options.columns = line;
     return;
   } else if (typeof this.options.columns === 'function') {
-    this.options.columns = this.options.columns(line);
+    try {
+      this.options.columns = this.options.columns(line);
+    } catch (err) {
+      this.emit('error', err);
+    }
     return;
   }
   if (!this.line_length && line.length > 0) {


### PR DESCRIPTION
Hey @wdavidw, I tried to look for the coffee scripts sources but was unable to find them, so I went ahead and modified the generated Js file.

I added the option to throw an error if the first line doesn't match an expected format, so the error is reported as any other in the parsing process.

Also, I took @wmcmurray change as starting point, please let me know if it's OK.