### PR TITLE
Make the parser more sensitive to input

### DIFF
--- a/test/rowDelimiter.coffee
+++ b/test/rowDelimiter.coffee
@@ -52,7 +52,27 @@ describe 'rowDelimiter', ->
     parser.write ':"GHI","94"::'
     parser.write '"JKL","02"'
     parser.end()
-  
+
+  it 'handle chuncks of multiple chars without quotes', (next) ->
+    data = []
+    parser = parse rowDelimiter: '::'
+    parser.on 'readable', ->
+      while d = parser.read()
+        data.push d
+    parser.on 'finish', ->
+      data.should.eql [
+        [ 'ABC','45' ]
+        [ 'DEF','23' ]
+        [ 'GHI','94' ]
+        [ 'JKL','02' ]
+      ]
+      next()
+    parser.write 'ABC,45'
+    parser.write '::DEF,23:'
+    parser.write ':GHI,94::'
+    parser.write 'JKL,02'
+    parser.end()
+
   it 'handle chuncks in autodiscovery', (next) ->
     data = []
     parser = parse()

--- a/test/write.coffee
+++ b/test/write.coffee
@@ -53,4 +53,13 @@ describe 'write', ->
     # buff = new Buffer [0xE2, 0x82, 0xAC]
     # parser.write buff
     parser.end()
-  
+
+  it 'instantly emits data once a newline is retrieved', (next) ->
+    data = []
+    parser = parse()
+    parser.write 'A,B,C\n'
+    parser.on 'data', (data) ->
+      data.should.eql ['A', 'B', 'C']
+      parser.end()
+    parser.on 'finish', ->
+      next()


### PR DESCRIPTION
This fixes #96.

Current implementation of parser is somewhat lazy because it always secure the excess bytes (whose length is `acceptedLength`) in the buffer (`@buf`). It makes the timing of data emission a bit late after the read of the end of line.

I made the process of checking if the remaining buffer can be special sequence more strict, and made the parser more sensitive to the input. Now it can push the row data immediately after the newline is written to the parser.

Now that `@buf` can be empty and `__write` function is callable with an empty buffer, I added the flushing process after the main loop, because the empty buffer bypasses the loop and the flushing process inside of it.