### PR TITLE
Fix incomplete multibyte characters at the end of the Buffer

### DIFF
--- a/lib/sync.js
+++ b/lib/sync.js
@@ -25,7 +25,7 @@ module.exports = function(data, options) {
   };
   parser.__write(data, false);
   if (data instanceof Buffer) {
-    parser.__write(data.end(), true);
+    parser.__write(decoder.end(data), true);
   }
   parser._flush((function() {}));
   return records;

--- a/src/sync.coffee.md
+++ b/src/sync.coffee.md
@@ -20,6 +20,6 @@ Usage: `records = parse(data, [options]`
         else
           records.push record
       parser.__write data, false
-      parser.__write data.end(), true if data instanceof Buffer
+      parser.__write decoder.end(data), true if data instanceof Buffer
       parser._flush (->)
       records


### PR DESCRIPTION
> When a Buffer instance is written to the StringDecoder instance, an internal buffer is used to ensure that the decoded string does not contain any incomplete multibyte characters. These are held in the buffer until the next call to stringDecoder.write() or until stringDecoder.end() is called.

(From https://nodejs.org/api/string_decoder.html)