### PR TITLE
Added better error message for when the max field length is exceeded

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -493,7 +493,7 @@ Parser.prototype.__write = function(chars, end) {
       i++;
     }
     if (!this._.commenting && ((ref2 = this._.field) != null ? ref2.length : void 0) > this.options.max_limit_on_data_read) {
-      return Error("Delimiter not found in the file " + (JSON.stringify(this.options.delimiter)));
+      return Error("Field exceeds max_limit_on_data_read setting (" + this.options.max_limit_on_data_read + ") " + (JSON.stringify(this.options.delimiter)));
     }
     if (!this._.commenting && ((ref3 = this._.line) != null ? ref3.length : void 0) > this.options.max_limit_on_data_read) {
       return Error("Row delimiter not found in the file " + (JSON.stringify(this.options.rowDelimiter)));

--- a/src/index.coffee.md
+++ b/src/index.coffee.md
@@ -382,7 +382,7 @@ Implementation of the [`stream.Transform` API][transform]
         else
           i++
         if not @_.commenting and @_.field?.length > @options.max_limit_on_data_read
-          return Error "Delimiter not found in the file #{JSON.stringify(@options.delimiter)}"
+          return Error "Field exceeds max_limit_on_data_read setting (#{@options.max_limit_on_data_read}) #{JSON.stringify(@options.delimiter)}"
         if not @_.commenting and @_.line?.length > @options.max_limit_on_data_read
           return Error "Row delimiter not found in the file #{JSON.stringify(@options.rowDelimiter)}"
       # Flush remaining fields and lines

--- a/test/options.delimiter.coffee
+++ b/test/options.delimiter.coffee
@@ -61,6 +61,6 @@ describe 'delimiter', ->
     a,b,c
     a,b,c
     """, delimiter: ':', rowDelimiter: '\t\t', max_limit_on_data_read: 10, (err, data) ->
-      err.message.should.eql 'Delimiter not found in the file ":"' if err
+      err.message.should.eql 'Field exceeds max_limit_on_data_read setting (10) ":"' if err
       should(data).not.be.ok()
       next()


### PR DESCRIPTION
@wdavidw Spent a while chasing down an error about the 'field delimiter', but it was the length of the field that was the problem.  Just improving the error message.